### PR TITLE
Add some Hedgehog tests (tripping, props, etc.)

### DIFF
--- a/hashids.cabal
+++ b/hashids.cabal
@@ -22,17 +22,21 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-test-suite consistency
+test-suite hashids-test
   type:                exitcode-stdio-1.0
   main-is:             Test.hs
+  other-modules:       Test.Web.Hashids.Gen
+                       Test.Web.Hashids.Property
   build-depends:       base
                      , bytestring
                      , containers
                      , hashids
+                     , hedgehog
                      , split
 
   hs-source-dirs:      test
   default-language:    Haskell2010
+  ghc-options:         -threaded
 
 Source-Repository head
   type: git

--- a/src/Web/Hashids.hs
+++ b/src/Web/Hashids.hs
@@ -209,7 +209,8 @@ data HashidsContext = Context
     , seps          :: !ByteString
     , salt          :: !ByteString
     , minHashLength :: !Int
-    , alphabet      :: !ByteString }
+    , alphabet      :: !ByteString
+    } deriving (Show)
 
 -- | Hashids version number.
 version :: String

--- a/test/Test/Web/Hashids/Gen.hs
+++ b/test/Test/Web/Hashids/Gen.hs
@@ -1,0 +1,59 @@
+module Test.Web.Hashids.Gen
+    ( genAlphabet
+    , genMinHashLength
+    , genSalt
+    , genHashidsContext
+    , genHashidsContextWithAlphabet
+    , genHashidsContextWithMinLen
+    , genHashidsContextWithSalt
+    ) where
+
+import           Control.Applicative ((<$>))
+import           Data.ByteString     (ByteString)
+import           Data.List           (nub)
+import           Data.Set            (toList)
+import           Hedgehog            (Gen)
+import qualified Hedgehog.Gen        as Gen
+import qualified Hedgehog.Range      as Range
+
+import           Web.Hashids
+
+genAlphabet :: Gen String
+genAlphabet =
+    nub
+        <$> toList
+        <$> Gen.set (Range.linear 16 62) Gen.alphaNum
+
+genMinHashLength :: Gen Int
+genMinHashLength = Gen.integral (Range.linear 1 1024)
+
+genSalt :: Gen ByteString
+genSalt = Gen.bytes (Range.linear 1 1024)
+
+genHashidsContext :: Gen HashidsContext
+genHashidsContext = do
+    createHashidsContext
+        <$> genSalt
+        <*> genMinHashLength
+        <*> genAlphabet
+
+genHashidsContextWithAlphabet :: String -> Gen HashidsContext
+genHashidsContextWithAlphabet alphabet =
+    createHashidsContext
+        <$> genSalt
+        <*> genMinHashLength
+        <*> pure alphabet
+
+genHashidsContextWithMinLen :: Int -> Gen HashidsContext
+genHashidsContextWithMinLen minHashLength =
+    createHashidsContext
+        <$> genSalt
+        <*> pure minHashLength
+        <*> genAlphabet
+
+genHashidsContextWithSalt :: ByteString -> Gen HashidsContext
+genHashidsContextWithSalt salt =
+    createHashidsContext
+        <$> pure salt
+        <*> genMinHashLength
+        <*> genAlphabet

--- a/test/Test/Web/Hashids/Property.hs
+++ b/test/Test/Web/Hashids/Property.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Web.Hashids.Property
+    ( tests
+    ) where
+
+import           Control.Applicative   ((<$>))
+import qualified Data.ByteString       as BS
+import qualified Data.ByteString.Char8 as C
+import           Hedgehog              (Property, assert, checkParallel,
+                                        discover, forAll, property, tripping,
+                                        withTests)
+import qualified Hedgehog.Gen          as Gen
+import qualified Hedgehog.Range        as Range
+
+import           Web.Hashids
+
+import           Test.Web.Hashids.Gen  (genAlphabet, genHashidsContext,
+                                        genHashidsContextWithAlphabet,
+                                        genHashidsContextWithMinLen,
+                                        genHashidsContextWithSalt,
+                                        genMinHashLength, genSalt)
+
+prop_tripping :: Property
+prop_tripping =
+    withTests 500 $ property $ do
+        context <- forAll genHashidsContext
+        x       <- forAll (Gen.integral Range.constantBounded)
+        tripping x (encode context) (decode context)
+
+prop_trippingUsingSalt :: Property
+prop_trippingUsingSalt =
+    withTests 500 $ property $ do
+        salt <- forAll genSalt
+        x    <- forAll (Gen.integral Range.constantBounded)
+        tripping x (encodeUsingSalt salt) (decodeUsingSalt salt)
+
+prop_encNotEqualToPlain :: Property
+prop_encNotEqualToPlain =
+    withTests 500 $ property $ do
+        context <- forAll genHashidsContext
+        x       <- forAll (Gen.integral Range.constantBounded)
+        let hashids     = encode context x
+            xByteString = C.pack $ show x
+        assert $ hashids /= xByteString
+
+prop_encDifferentSaltsNotEqual :: Property
+prop_encDifferentSaltsNotEqual =
+    withTests 500 $ property $ do
+        salt1    <- forAll genSalt
+        salt2    <- forAll genSalt
+        context1 <- forAll (genHashidsContextWithSalt salt1)
+        context2 <- forAll (genHashidsContextWithSalt salt2)
+        x        <- forAll (Gen.integral Range.constantBounded)
+        let hashids1 = encode context1 x
+            hashids2 = encode context2 x
+        assert $ hashids1 /= hashids2
+
+prop_encOnlyConsistsOfAlphabet :: Property
+prop_encOnlyConsistsOfAlphabet =
+    withTests 500 $ property $ do
+        alphabet <- forAll genAlphabet
+        context  <- forAll (genHashidsContextWithAlphabet alphabet)
+        x        <- forAll (Gen.integral Range.constantBounded)
+        let hashids = encode context x
+        assert $ not $ C.any ((flip notElem) alphabet) hashids
+
+prop_encMinLength :: Property
+prop_encMinLength =
+    withTests 500 $ property $ do
+        minHashLength <- forAll genMinHashLength
+        context       <- forAll (genHashidsContextWithMinLen minHashLength)
+        x             <- forAll (Gen.integral Range.constantBounded)
+        let hashids = encode context x
+        assert $ BS.length hashids >= minHashLength
+
+tests :: IO Bool
+tests = and <$> sequence
+    [ checkParallel $$(discover)
+    ]


### PR DESCRIPTION
_Note: I recommend first reviewing #7 and #8 since this PR actually makes some usage of `stylish-haskell` and also restructures the filesystem layout for tests and cleans up the `cabal` file a bit._

Added some tripping tests and a number of other property tests. There are still some other tests which can be added, but this is just a start.