### PR TITLE
Add package.yaml and regenerate hashids.cabal with hpack

### DIFF
--- a/hashids.cabal
+++ b/hashids.cabal
@@ -1,43 +1,58 @@
-name:                hashids
-version:             1.0.2.5
-synopsis:            Hashids generates short, unique, non-sequential ids from numbers.
-description:         This is a Haskell port of the Hashids library. It is typically used to encode numbers to a format suitable to appear in visible places like urls. It converts numbers like 347 into strings like yr8, or a list of numbers like [27, 986] into 3kTMd. You can also decode those ids back. This is useful in bundling several parameters into one.
-homepage:            http://hashids.org/
-license:             MIT
-license-file:        LICENSE
-author:              Johannes Hildén
-maintainer:          hildenjohannes@gmail.com
-category:            Web
-build-type:          Simple
-extra-source-files:  test/testdata/*.txt
-cabal-version:       >=1.10
+-- This file has been generated from package.yaml by hpack version 0.28.2.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 3c7a200423f3757070915ba95d9e9fe6c80ed6ee16dd3d6c5bdf4ed17f37e009
 
-library
-  exposed-modules:     Web.Hashids
-  build-depends:       base
-                     , bytestring
-                     , containers
-                     , split
+name:           hashids
+version:        1.0.2.5
+synopsis:       Hashids generates short, unique, non-sequential ids from numbers.
+description:    This is a Haskell port of the Hashids library. It is typically used to encode numbers to a format suitable to appear in visible places like urls. It converts numbers like 347 into strings like yr8, or a list of numbers like [27, 986] into 3kTMd. You can also decode those ids back. This is useful in bundling several parameters into one.
+category:       Web
+homepage:       http://hashids.org/
+bug-reports:    https://github.com/laserpants/hashids-haskell/issues
+author:         Johannes Hildén <hildenjohannes@gmail.com>
+maintainer:     Johannes Hildén <hildenjohannes@gmail.com>
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
+extra-source-files:
+    test/testdata/testdata1.txt
 
-  hs-source-dirs:      src
-  default-language:    Haskell2010
-
-test-suite hashids-test
-  type:                exitcode-stdio-1.0
-  main-is:             Test.hs
-  other-modules:       Test.Web.Hashids.Gen
-                       Test.Web.Hashids.Property
-  build-depends:       base
-                     , bytestring
-                     , containers
-                     , hashids
-                     , hedgehog
-                     , split
-
-  hs-source-dirs:      test
-  default-language:    Haskell2010
-  ghc-options:         -threaded
-
-Source-Repository head
+source-repository head
   type: git
   location: https://github.com/laserpants/hashids-haskell
+
+library
+  exposed-modules:
+      Web.Hashids
+  other-modules:
+      Paths_hashids
+  hs-source-dirs:
+      src
+  build-depends:
+      base
+    , bytestring
+    , containers
+    , split
+  default-language: Haskell2010
+
+test-suite hashids-test
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  other-modules:
+      Test.Web.Hashids.Gen
+      Test.Web.Hashids.Property
+      Paths_hashids
+  hs-source-dirs:
+      test
+  ghc-options: -threaded
+  build-depends:
+      base
+    , bytestring
+    , containers
+    , hashids
+    , hedgehog
+    , split
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,35 @@
+name: hashids
+version: 1.0.2.5
+synopsis: Hashids generates short, unique, non-sequential ids from numbers.
+description: This is a Haskell port of the Hashids library. It is typically used to encode numbers to a format suitable to appear in visible places like urls. It converts numbers like 347 into strings like yr8, or a list of numbers like [27, 986] into 3kTMd. You can also decode those ids back. This is useful in bundling several parameters into one.
+homepage: http://hashids.org/
+license: MIT
+license-file: LICENSE
+author: Johannes Hildén <hildenjohannes@gmail.com>
+maintainer: Johannes Hildén <hildenjohannes@gmail.com>
+github: laserpants/hashids-haskell
+category: Web
+build-type: Simple
+extra-source-files:
+  - test/testdata/*.txt
+
+dependencies:
+  - base
+  - bytestring
+  - containers
+  - split
+
+library:
+  source-dirs: src
+  exposed-modules:
+    - Web.Hashids
+
+tests:
+  hashids-test:
+    main: Test.hs
+    source-dirs:
+      - test
+    dependencies:
+      - hashids
+      - hedgehog
+    ghc-options: -threaded


### PR DESCRIPTION
This PR adds support for `hpack` (a suggestion by @laserpants in a [comment](https://github.com/laserpants/hashids-haskell/pull/9#issuecomment-451755294) on #9).